### PR TITLE
Deduplicate events from UKA

### DIFF
--- a/server/import/import_scripts/google_drive.js
+++ b/server/import/import_scripts/google_drive.js
@@ -37,8 +37,6 @@ function parseEvents (eventData, callback) {
                 return;
             }
 
-            console.log(row);
-
             var externalID = (index + 1).toString();
             var imageUrl = "http://barteguiden.no/v1/images/" + externalID + ".jpg";
 

--- a/server/import/server_sync.js
+++ b/server/import/server_sync.js
@@ -3,7 +3,8 @@ var Event = require('../models/Event.js');
 exports.sync = function(events) {
     events.map(function(evt) {
         var query = {
-            'eventUrl': evt.eventUrl
+            'title': evt.title,
+            'startAt': evt.startAt
         };
         Event.findOne(
             query,
@@ -15,7 +16,7 @@ exports.sync = function(events) {
                         }
                     }
                 );}
-                
+
             }
         );
 


### PR DESCRIPTION
The API is broken, and spits out a lot of different events in different
forms. The deduplication is based on adding all the showings of an
event to one event object, and then removing the duplicates by using the
show date as a key.

@martinhath MVP :+1: 