### PR TITLE
Add events from trdevents.no

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -16,12 +16,6 @@ body {
   padding-bottom: 20px;
 }
 
-.container {
-
-  max-width: 800px;
-
-}
-
 .angular-google-map-container {
 
   height: 400px;

--- a/server/import/import_scripts/google_drive.js
+++ b/server/import/import_scripts/google_drive.js
@@ -148,7 +148,9 @@ var mapping = {
     "13": {
         key: "isPublished",
         transform: function (value) {
-            return (value.toLowerCase() === "yes") ? true: false;
+            if (value.toLowerCase() === 'yes' || !value)
+                return true;
+            return false;
         }
     }
 };

--- a/server/import/import_scripts/samfundet.js
+++ b/server/import/import_scripts/samfundet.js
@@ -88,10 +88,7 @@ function findPrice($) {
 
 var mapping = {
     "title.0": {
-        key: "title",
-        transform: function (value) {
-            return value.trim();
-        }
+        key: "title"
     },
     "pubDate.0": {
         key: "startAt",

--- a/server/import/import_scripts/trdevents.js
+++ b/server/import/import_scripts/trdevents.js
@@ -36,7 +36,9 @@ function parseEvents (externalEvents) {
     var outputEvents = [];
 
     externalEvents.forEach(function(event) {
-        var event = mapper.merge(event, {}, mapping);
+        var event = mapper.merge(event, {
+            isPublished: false
+        }, mapping);
         if (event.category !== 'REMOVE' && event.venue.name !== 'Studentersamfundet') {
             outputEvents.push(event);
         }
@@ -47,10 +49,7 @@ function parseEvents (externalEvents) {
 
 var mapping = {
     "title.0": {
-        key: "title",
-        transform: function (value) {
-            return value.trim();
-        }
+        key: "title"
     },
     "ev:tribeEventMeta.0.ev:startdate.0": {
         key: "startAt",
@@ -108,22 +107,13 @@ var mapping = {
         key: "eventUrl"
     },
     "ev:tribeEventMeta.0.ev:picture.0": {
-        key: "imageUrl",
-        transform: function (value) {
-            return value.trim();
-        }
+        key: "imageUrl"
     },
     "ev:tribeEventMeta.0.ev:venueName.0": {
-        key: "venue.name",
-        transform: function (value) {
-            return value.trim();
-        }
+        key: "venue.name"
     },
     "ev:tribeEventMeta.0.ev:venueStreet.0": {
-        key: "venue.address",
-        transform: function (value) {
-            return value.trim();
-        }
+        key: "venue.address"
     },
     "ev:tribeEventMeta.0.ev:venueLat.0": {
         key: "venue.latitude",

--- a/server/import/import_scripts/trdevents.js
+++ b/server/import/import_scripts/trdevents.js
@@ -1,0 +1,150 @@
+var request = require("request");
+var xml2js = require("xml2js");
+var mapper = require("object-mapper");
+var serverSync = require("../server_sync");
+
+var parser = new xml2js.Parser();
+
+var externalURL = "https://trdevents.no/feed/";
+
+exports.insertEvents = function getEventsFromExternalSource () {
+    for (var i = 1; i <= 10; i++) {
+        var query = {paged: i};
+        request({
+            method: "GET",
+            uri: externalURL,
+            qs: query,
+            encoding: "utf8",
+            headers: {
+                'User-Agent': 'Barteguiden'
+            }
+        }, function (error, response, body) {
+            if (!error && response.statusCode === 200) {
+                parser.parseString(body);
+            }
+        });
+    }
+}
+
+parser.on("end", function(result) {
+    var data = mapper.getKeyValue(result, "rss.channel.0.item");
+    var events = parseEvents(data);
+    serverSync.sync(events);
+});
+
+function parseEvents (externalEvents) {
+    var outputEvents = [];
+
+    externalEvents.forEach(function(event) {
+        var event = mapper.merge(event, {}, mapping);
+        if (event.category !== 'REMOVE' && event.venue.name !== 'Studentersamfundet') {
+            outputEvents.push(event);
+        }
+    });
+
+    return outputEvents;
+}
+
+var mapping = {
+    "title.0": {
+        key: "title",
+        transform: function (value) {
+            return value.trim();
+        }
+    },
+    "ev:tribeEventMeta.0.ev:startdate.0": {
+        key: "startAt",
+        transform: function (value) {
+            var date = new Date(value.trim());
+            return date.toISOString();
+        }
+    },
+
+    "ev:tribeEventMeta.0.ev:enddate.0": {
+        key: "endAt",
+        transform: function (value) {
+            var date = new Date(value.trim());
+            return date.toISOString();
+        }
+    },
+
+    "ev:tribeEventMeta.0.ev:normalPrice.0": {
+        key: "price"
+    },
+
+    "ev:tribeEventMeta.0.ev:ageRestriction.0": {
+        key: "ageLimit",
+        transform: function (value) {
+            var ageLimit = parseInt(value, 10);
+            return (!isNaN(ageLimit)) ? ageLimit : 0;
+        }
+    },
+    "ev:tribeEventMeta.0.ev:categories.0.category.0.categoryName.0": {
+        key: "category",
+        transform: function (value) {
+            if(!value) {
+                value = 'Barn';
+            }
+
+            var category = value.trim();
+
+            if (category === 'Barn' || category === 'Familie') {
+                return 'REMOVE';
+
+            }
+            return categoryMapping[category] || 'OTHER';
+        }
+    },
+    "description.0": {
+        key: "description"
+    },
+    "isPromoted.0": {
+        key: "isPromoted",
+        transform: function () {
+            return false;
+        }
+    },
+    "link.0": {
+        key: "eventUrl"
+    },
+    "ev:tribeEventMeta.0.ev:picture.0": {
+        key: "imageUrl",
+        transform: function (value) {
+            return value.trim();
+        }
+    },
+    "ev:tribeEventMeta.0.ev:venueName.0": {
+        key: "venue.name",
+        transform: function (value) {
+            return value.trim();
+        }
+    },
+    "ev:tribeEventMeta.0.ev:venueStreet.0": {
+        key: "venue.address",
+        transform: function (value) {
+            return value.trim();
+        }
+    },
+    "ev:tribeEventMeta.0.ev:venueLat.0": {
+        key: "venue.latitude",
+        transform: function (value) {
+            return Number(value.trim());
+        }
+    },
+    "ev:tribeEventMeta.0.ev:venueLng.0": {
+        key: "venue.longitude",
+        transform: function (value) {
+            return Number(value.trim());
+        }
+    }
+};
+
+var categoryMapping = {
+    "Konsert": "MUSIC",
+    "Foredrag": "PRESENTATIONS",
+    "Møte": "DEBATE",
+    "Happening": "NIGHTLIFE",
+    "Kurs": "OTHER",
+    "Show": "PERFORMANCES",
+    "Fotballkamp": "SPORT",
+};

--- a/server/import/jobs.js
+++ b/server/import/jobs.js
@@ -2,7 +2,8 @@ var CronJob = require('cron').CronJob;
 var feeds = [
     require('./import_scripts/samfundet.js'),
     require('./import_scripts/uka.js'),
-    require('./import_scripts/google_drive.js')
+    require('./import_scripts/google_drive.js'),
+    require('./import_scripts/trdevents.js')
 ];
 
 module.exports = new CronJob('00 30 11 * * 0-6', function(){

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -20,6 +20,6 @@ var EventSchema = new mongoose.Schema({
     eventUrl: {type: String, trim: true},
     isPromoted: {type: Boolean, default: false},
     isPublished: {type: Boolean, default: false}
-})
+}, {timestamps: true})
 
 module.exports = mongoose.model('Event', EventSchema);

--- a/server/models/Event.js
+++ b/server/models/Event.js
@@ -2,24 +2,24 @@ var mongoose = require('mongoose');
 
 
 var EventSchema = new mongoose.Schema({
-    title: String,
-    description: String,
+    title: {type: String, trim: true},
+    description: {type: String, trim: true},
     startAt: Date,
     endAt: Date,
     venue: {
-        name: String,
-        address: String,
+        name: {type: String, trim: true},
+        address: {type: String, trim: true},
         longitude: Number,
         latitude: Number
     },
     ageLimit: Number,
     price: Number,
-    category: String,
+    category: {type: String, trim: true},
     tags: [String],
-    imageUrl: String,
-    eventUrl: String,
-    isPromoted: Boolean,
-    isPublished: Boolean
+    imageUrl: {type: String, trim: true},
+    eventUrl: {type: String, trim: true},
+    isPromoted: {type: Boolean, default: false},
+    isPublished: {type: Boolean, default: false}
 })
 
 module.exports = mongoose.model('Event', EventSchema);


### PR DESCRIPTION
Fetches the ~ 100 last updated events from trdevents.no 
*Todo:* 
* These events should be manually published I think (`isPublished` is set to `false`). This will need some changes on both frontend and backend as all events are published now regardless of `isPublished`. 
* Update `categoryMapping` (most of the events are now categorized as OTHER). 
* If an event changes, we must use a smarter heuristic than comparing `title` and `startAt` (this applies to Samfundet and UKA as well). 
* The event description is raw HTML, must find a way to handle that on the different platforms. 