### PR TITLE
Change GET api/events to only published events

### DIFF
--- a/app/scripts/services/eventservice.js
+++ b/app/scripts/services/eventservice.js
@@ -30,7 +30,8 @@ angular.module('barteguidenMarkedsWebApp.services')
       },
       query: {
         method: 'GET',
-        isArray: true
+        isArray: true,
+        params: { published: 'all' }
       }
     });
   });

--- a/server/controllers/event.js
+++ b/server/controllers/event.js
@@ -17,13 +17,26 @@ exports.postEvents = function(req, res){
 // GET /api/events
 exports.getEvents = function(req, res){
     var time = moment().subtract(6, 'hours').valueOf();
-    Event.find()
-    .where('startAt').gt(time)
-    .exec(function(err, events) {
-        if(err)
-            res.send(err);
-        res.json(events);
-    });
+    var findEvents = Event.find().where('startAt').gt(time);
+
+    if (req.query.published === 'all') {
+        findEvents
+            .exec(function(err, events) {
+                if(err)
+                    res.send(err);
+                res.json(events);
+            });
+    }
+    else {
+        findEvents
+            .where('isPublished').equals(true)
+            .exec(function(err, events) {
+                if(err)
+                    res.send(err);
+                res.json(events);
+            });
+    }
+
 };
 
 // GET /api/events/:event_id


### PR DESCRIPTION
A special query param `published=all` must be added to the request to get every event. Not a good API solution, but the quickest one for backward compatibility. Closes #69.