### PR TITLE
Make externalId extraction from Samfundet more general

### DIFF
--- a/server/import/import_scripts/samfundet.js
+++ b/server/import/import_scripts/samfundet.js
@@ -131,7 +131,8 @@ var mapping = {
     "guid.0": {
         key: "externalId",
         transform: function(link) {
-            return parseInt(link.replace("https://www.samfundet.no/arrangement/", "").split("-", 1)[0]);
+            var splitLink = link.split("/");
+            return parseInt(splitLink[splitLink.length - 1].split("-", 1)[0]);
         }
     }
 };


### PR DESCRIPTION
If the url in the replace function didn't match reality (which it didn't because the www part might not always be there), certain events from Samfundet would not get imported.

This solution still assumes that the ID is placed before the first "-" after the last "/" in the url, but the format of the url before this doesn't matter.
