### PR TITLE
Add missing category mappings

### DIFF
--- a/server/import/import_scripts/category_mapping.js
+++ b/server/import/import_scripts/category_mapping.js
@@ -24,8 +24,6 @@ module.exports = {
     "Samfunn": "DEBATE",
     "Festival": "PERFORMANCES",
     "Sport": "SPORT",
-    "Forestilling": "PERFORMANCES"
+    "Forestilling": "PERFORMANCES",
+    "Utstilling" : "EXHIBITIONS"
 };
-
-
-

--- a/server/import/import_scripts/category_mapping.js
+++ b/server/import/import_scripts/category_mapping.js
@@ -25,5 +25,6 @@ module.exports = {
     "Festival": "PERFORMANCES",
     "Sport": "SPORT",
     "Forestilling": "PERFORMANCES",
-    "Utstilling" : "EXHIBITIONS"
+    "Utstilling" : "EXHIBITIONS",
+    "Festmøte" : "DEBATE"
 };


### PR DESCRIPTION
Too many exhibition events from TRDEvents and Festmøte-events from Samfundet got the "other"-category
