### PR TITLE
Do not overwrite category if external event is imported

### DIFF
--- a/server/import/server_sync.js
+++ b/server/import/server_sync.js
@@ -5,18 +5,33 @@ exports.sync = function(events) {
     events.map(function(evt) {
 
         if (evt.externalId) {
-            Event.findOneAndUpdate(
-                {'externalId': evt.externalId},
-                evt,
-                {'upsert': true},
-                function(err, doc) {
-                    if (err) {
-                        console.error("Event error: ", err);
-                    }
+            Event.findOne({'externalId': evt.externalId}, function(err, doc) {
+                if (!doc) {
+                    Event.findOneAndUpdate(
+                        {'externalId': evt.externalId},
+                        evt,
+                        {'upsert': true},
+                        function(err, doc) {
+                            if (err) {
+                                console.error("Event error: ", err);
+                            }
+                        }
+                    );
                 }
-            );
+                else {
+                    delete evt.category;
+                    Event.findOneAndUpdate(
+                        {'externalId': evt.externalId},
+                        evt,
+                        function(err, doc) {
+                            if (err) {
+                                console.error("Event error: ", err);
+                            }
+                        }
+                    );
+                }
+            });
         }
-
         else {
             Event.findOne(
                 {


### PR DESCRIPTION
This is an ugly hack to fix the issue with all changes to facebook events (except age limit and price) being overwritten every day, resulting in a lot of events with the OTHER category. We should handle events differently based on where they come from.

Resolves #91
