### PR TITLE
Remove published checkbox on invalid Facebook events

### DIFF
--- a/app/scripts/controllers/main.js
+++ b/app/scripts/controllers/main.js
@@ -136,5 +136,9 @@ angular.module('barteguidenMarkedsWebApp.controllers')
       if($scope.currentPage != 1) {
         $rootScope.currentPage = $scope.currentPage;
       }
-    }
+    };
+
+    $scope.isValidEvent = function(evt) {
+      return evt.price && evt.ageLimit && evt.title && evt.venue.name;
+    };
   }]);

--- a/app/views/main.html
+++ b/app/views/main.html
@@ -79,7 +79,9 @@
         {{event.venue.name}}
       </td>
       <td>
-        <input type="checkbox" name="published" value="{{value}}" ng-click="togglePublished(event._id);event.isPublished=!event.isPublished;" ng-checked="{{event.isPublished}}">
+        <input type="checkbox" name="published" value="{{value}}" ng-if="isValidEvent(event)"
+          ng-click="togglePublished(event._id);event.isPublished=!event.isPublished;"
+          ng-checked="{{event.isPublished}}">
       </td>
       <td>
         <a ng-href="#/edit/{{event._id}}" class="btn btn-xs btn-info">Endre</a>


### PR DESCRIPTION
Not failproof by any means, but a useful heuristic.
Fixes #96.
