### PR TITLE
Added functionality for "merging" venues

### DIFF
--- a/app/views/venuemergemodal.html
+++ b/app/views/venuemergemodal.html
@@ -1,0 +1,54 @@
+<!--
+~ Copyright 2016 Studentmediene i Trondheim AS
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<div class="modal-header">
+  <h3 class="modal-title">Velg representant for stedene</h3>
+</div>
+<div class="modal-body">
+  <div class="table-responsive">
+    <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>
+          <span>Navn</span>
+        </th>
+        <th>
+          <span>Adresse</span>
+        </th>
+        <th>
+          <span>Representant</span>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr ng-repeat="venue in selectedVenues | orderBy : 'name'">
+        <td>
+          {{venue.name}}
+        </td>
+        <td>
+          {{venue.address}}
+        </td>
+        <td>
+          <input type="radio" name="representative" value="{{venue.name}}" ng-click="setRepresentative(venue)">
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+<div class=modal-footer>
+  <button class="btn-warning btn" ng-click="okMergeVenues()" ng-if="representativeVenue!=undefined">Ok</button>
+  <button class="btn btn-info" ng-click="cancel()">Avbryt</button>
+</div>

--- a/app/views/venues.html
+++ b/app/views/venues.html
@@ -17,13 +17,20 @@
 <div class="input-group row">
   <div class="col-md-4">
     <button class="btn btn-md btn-info" ng-click="addVenue()">
-      <span class="glyphicon glyphicon-plus"></span> Legg til sted
+      Legg til sted
     </button>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-4">
     <div class="input-group">
       <input ng-model="search.name" type="text" class="form-control" aria-label="..." placeholder="Søk på sted">
     </div>
+  </div>
+  <div class="col-md-4">
+    <button class="btn btn-md btn-warning" ng-click="openModalMergeVenues()"
+      ng-if="numberToMerge > 1"
+      >
+      Slå sammen steder
+    </button>
   </div>
 </div>
 <div class="table-responsive">
@@ -36,7 +43,7 @@
       <th>
         <a href="" ng-click="order('address')">Adresse</a>
       </th>
-      <th>Endre</th><th>Slett</th>
+      <th>Slå sammen</th><th>Endre</th><th>Slett</th>
     </tr>
     </thead>
     <tbody>
@@ -46,6 +53,11 @@
       </td>
       <td>
         {{venue.address}}
+      </td>
+      <td>
+        <input type="checkbox" name="tomerge" value="{{value}}"
+          ng-click="toggleToMerge(venue)"
+          ng-checked="false" ng-model="venue.selectedForMerge">
       </td>
       <td>
         <button ng-click="editVenue(venue._id)" class="btn btn-xs btn-info">Endre</button>

--- a/server/models/Venue.js
+++ b/server/models/Venue.js
@@ -3,6 +3,7 @@ var mongoose = require('mongoose');
 
 var VenueSchema = new mongoose.Schema({
     name: {type: String, trim: true},
+    aliases: {type: [String], required: true, default: []},
     address: {type: String, trim: true},
     latitude: Number,
     longitude: Number


### PR DESCRIPTION
Warning: Be aware that this may cause some issues
The way this works, is that the "aliases" field has been added to the Venue model.
This is a list containing names that we define to be names of venues equal to the one that the object represents.
Also, events are changed so that they refer to the name of the "mother"-venue when the original name is found to be just an alias.

Fixes (at least partially) #98 